### PR TITLE
feat(groups): add attributes to group membersips

### DIFF
--- a/examples/example-yaml-files/users.yaml
+++ b/examples/example-yaml-files/users.yaml
@@ -15,5 +15,8 @@ jane:
   archived: false
   suspended: false
   roles:
-    - one-group
-    - another-group
+    - group: one-group
+      delivery_settings: DAILY
+      role: MANAGER
+      type: USER
+    - group: another-group

--- a/modules/users/variables.tf
+++ b/modules/users/variables.tf
@@ -17,7 +17,12 @@ variable "user" {
     is_admin : optional(bool),
     org_unit_path : optional(string),
     suspended : optional(bool),
-    roles : optional(list(string)),
+    roles : optional(list(object({
+      group : string,
+      delivery_settings : optional(string),
+      role : optional(string),
+      type : optional(string)
+    }))),
   })
 }
 

--- a/modules/users_external_to_groups/main.tf
+++ b/modules/users_external_to_groups/main.tf
@@ -12,7 +12,10 @@ terraform {
 # -----------------------------------------------------------------------------------------------------------------------------
 
 resource "googleworkspace_group_member" "group" {
-  for_each = toset(var.user_external.roles)
-  group_id = var.groups[each.value].email
-  email    = var.user_external_email
+  for_each          = toset(var.user_external.roles)
+  group_id          = var.groups[each.value.group].email
+  email             = var.user_external_email
+  delivery_settings = coalesce(each.value.delivery_settings, "ALL_MAIL") # defaults to ALL_MAIL
+  role              = coalesce(each.value.role, "MEMBER")                # defaults to MEMBER
+  type              = coalesce(each.value.type, "USER")                  # defaults to USER
 }

--- a/modules/users_external_to_groups/variables.tf
+++ b/modules/users_external_to_groups/variables.tf
@@ -18,8 +18,18 @@ variable "groups" {
 variable "user_external" {
   description = "contains an object representing an external User"
   type = object({
-    roles : list(string),
+    roles : list(object({
+      group : string,
+      delivery_settings : optional(string),
+      role : optional(string),
+      type : optional(string)
+    })),
   })
+
+  validation {
+    condition     = alltrue(flatten([for role in var.user_external.roles : contains(keys(var.groups), role.group)]))
+    error_message = "All groups must be defined in the groups variable."
+  }
 }
 
 variable "user_external_email" {

--- a/modules/users_to_groups/main.tf
+++ b/modules/users_to_groups/main.tf
@@ -13,6 +13,10 @@ terraform {
 
 resource "googleworkspace_group_member" "group" {
   for_each = toset(var.user.roles)
-  group_id = var.groups[each.value].email
-  email    = var.user.primary_email
+
+  group_id          = var.groups[each.value.group].email
+  email             = var.user.primary_email
+  delivery_settings = coalesce(each.value.delivery_settings, "ALL_MAIL") # defaults to ALL_MAIL
+  role              = coalesce(each.value.role, "MEMBER")                # defaults to MEMBER
+  type              = coalesce(each.value.type, "USER")                  # defaults to USER
 }

--- a/modules/users_to_groups/variables.tf
+++ b/modules/users_to_groups/variables.tf
@@ -17,8 +17,18 @@ variable "user" {
     is_admin : optional(bool),
     org_unit_path : optional(string),
     suspended : optional(bool),
-    roles : optional(list(string)),
+    roles : optional(list(object({
+      group : string,
+      delivery_settings : optional(string),
+      role : optional(string),
+      type : optional(string)
+    }))),
   })
+
+  validation {
+    condition     = alltrue(flatten([for role in var.user.roles : contains(keys(var.groups), role.group)]))
+    error_message = "All groups must be defined in the groups variable."
+  }
 }
 
 variable "groups" {


### PR DESCRIPTION
Changes:
- transform the `users.role` variable from a `list(str)` to a `list(map)` data structure
- This allows us to define membership attributes like `delivery_settings`, `role`, and `type`.
- Default values reflect the [default values](https://registry.terraform.io/providers/hashicorp/googleworkspace/latest/docs/resources/group_member#nestedblock--timeouts) from the provider.